### PR TITLE
Don't save non dirty files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,10 +29,12 @@ export function activate(context: vscode.ExtensionContext) {
                     progress.report({
                         message: `${i + 1}/${uris.length}`
                     });
-                    await vscode.window.showTextDocument(uris[i], { preserveFocus: false, preview: true });
+                    const editor = await vscode.window.showTextDocument(uri, { preserveFocus: false, preview: true });
                     await vscode.commands.executeCommand('editor.action.formatDocument', uri);
                     if (saveAfterFormat) {
-                        await vscode.commands.executeCommand('workbench.action.files.save', uri);
+                        if (editor.document.isDirty) {
+                            await vscode.commands.executeCommand('workbench.action.files.save', uri);
+                        }
                         if (closeAfterSave) {
                             await vscode.commands.executeCommand('workbench.action.closeActiveEditor', uri);
                         }


### PR DESCRIPTION
First great extension!

I have a accessibility tools that rely on file watchers. When I ran format on my entire workspace those tools went haywire when every single file updated. This pr makes a small tweak so that we only save a file if it's actually dirty(have unsaved changes).